### PR TITLE
Feature: Ignore File Extensions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Version 0.3.3
+------------
+Addition of ignored file extensions
+
+
 Version 0.1
 ------------
 First release

--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ Or staticfiles directories using: ::
 
 You can ignore file extensions: ::
 
-  $ ./manage.py livereload --ignore-extensions=.less,.scss
+  $ ./manage.py livereload --ignore-file-extensions=.less,.scss
 
 
 Extra files and/or paths to watch for changes can be added as positional arguments. By default livereload server watches the files that are found by your staticfiles finders and your template loaders. ::

--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,11 @@ Or staticfiles directories using: ::
 
   $ ./manage.py livereload --ignore-static-dirs
 
+You can ignore file extensions: ::
+
+  $ ./manage.py livereload --ignore-extensions=.less,.scss
+
+
 Extra files and/or paths to watch for changes can be added as positional arguments. By default livereload server watches the files that are found by your staticfiles finders and your template loaders. ::
 
   $ python manage.py livereload path/to/my-extra-directory/

--- a/livereload/__init__.py
+++ b/livereload/__init__.py
@@ -1,5 +1,5 @@
 """django-livereload"""
-__version__ = '0.3.2'
+__version__ = '0.3.3'
 __license__ = 'BSD License'
 
 __author__ = 'Tomas Walch'

--- a/livereload/management/commands/livereload.py
+++ b/livereload/management/commands/livereload.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
             help='Extra files or directories to watch',
         )
         parser.add_argument(
-            '--ignore-extensions',
+            '--ignore-file-extensions',
             action='store',
             help='File extensions to ignore',
         )
@@ -59,9 +59,9 @@ class Command(BaseCommand):
             watch_dirs.extend([os.path.join(app_config.path, 'static')
                                for app_config in app_configs])
 
-        ignored_extensions = options.get('ignore_extensions', '').split(',')
-        for extension in ignored_extensions:
-            server.ignore_extension(extension)
+        ignore_file_extensions = options.get('ignore_file_extensions', '').split(',')
+        for extension in ignore_file_extensions:
+            server.ignore_file_extension(extension)
 
         for dir in filter(None, watch_dirs):
             server.watch(dir)

--- a/livereload/management/commands/livereload.py
+++ b/livereload/management/commands/livereload.py
@@ -18,6 +18,11 @@ class Command(BaseCommand):
             help='Extra files or directories to watch',
         )
         parser.add_argument(
+            '--ignore-extensions',
+            action='store',
+            help='File extensions to ignore',
+        )
+        parser.add_argument(
             '--host', dest='host', default=livereload_host(), help='Host address for livereload sever.'
         )
         parser.add_argument(
@@ -53,6 +58,10 @@ class Command(BaseCommand):
             watch_dirs.extend(getattr(settings, 'STATICFILES_DIRS', []))
             watch_dirs.extend([os.path.join(app_config.path, 'static')
                                for app_config in app_configs])
+
+        ignored_extensions = options.get('ignore_extensions', '').split(',')
+        for extension in ignored_extensions:
+            server.ignore_extension(extension)
 
         for dir in filter(None, watch_dirs):
             server.watch(dir)

--- a/livereload/management/commands/livereload.py
+++ b/livereload/management/commands/livereload.py
@@ -61,7 +61,7 @@ class Command(BaseCommand):
 
         ignore_file_extensions = options.get('ignore_file_extensions', '').split(',')
         for extension in ignore_file_extensions:
-            server.ignore_file_extension(extension)
+            server.ignore_file_extension(extension.strip())
 
         for dir in filter(None, watch_dirs):
             server.watch(dir)

--- a/livereload/server.py
+++ b/livereload/server.py
@@ -94,7 +94,7 @@ class Server(object):
             watcher = watcher_cls()
         self.watcher = watcher
 
-    def ignore_extension(self, extension):
+    def ignore_file_extension(self, extension):
         """
         Configure a file extension to be ignored.
 
@@ -102,7 +102,7 @@ class Server(object):
                           (ex. .less, .scss, etc)
         """
         logger.info('Ignoring file extension: {}'.format(extension))
-        self.watcher.ignore_extension(extension)
+        self.watcher.ignore_file_extension(extension)
 
     def watch(self, filepath, func=None, delay=None):
         """Add the given filepath for watcher list.

--- a/livereload/server.py
+++ b/livereload/server.py
@@ -88,10 +88,21 @@ class Server(object):
                     CPU usage.
     """
     def __init__(self, watcher=None):
+        self._setup_logging()
         if not watcher:
             watcher_cls = get_watcher_class()
             watcher = watcher_cls()
         self.watcher = watcher
+
+    def ignore_extension(self, extension):
+        """
+        Configure a file extension to be ignored.
+
+        :param extension: file extension to be ignored
+                          (ex. .less, .scss, etc)
+        """
+        logger.info('Ignoring file extension: {}'.format(extension))
+        self.watcher.ignore_extension(extension)
 
     def watch(self, filepath, func=None, delay=None):
         """Add the given filepath for watcher list.
@@ -137,7 +148,6 @@ class Server(object):
         :param open_url_delay: open webbrowser after the delay seconds
         """
         host = host or '127.0.0.1'
-        self._setup_logging()
         logger.info('Serving on http://%s:%s' % (host, liveport))
 
         self.application(host, liveport=liveport)

--- a/livereload/watcher.py
+++ b/livereload/watcher.py
@@ -32,15 +32,15 @@ class Watcher(object):
         self._start = time.time()
 
         # ignored file extensions
-        self.ignored_extensions = ['.pyc', '.pyo', '.o', '.swp']
+        self.ignored_file_extensions = ['.pyc', '.pyo', '.o', '.swp']
 
     def should_ignore(self, filename):
         """Should ignore a given filename?"""
         _, ext = os.path.splitext(filename)
-        return ext in self.ignored_extensions
+        return ext in self.ignored_file_extensions
 
-    def ignore_extension(self, extension):
-        self.ignored_extensions.append(extension)
+    def ignore_file_extension(self, extension):
+        self.ignored_file_extensions.append(extension)
 
     def watch(self, path, func=None, delay=0, ignore=None):
         """Add a task to watcher.

--- a/livereload/watcher.py
+++ b/livereload/watcher.py
@@ -31,10 +31,16 @@ class Watcher(object):
         self.filepath = None
         self._start = time.time()
 
-    def ignore(self, filename):
-        """Ignore a given filename or not."""
+        # ignored file extensions
+        self.ignored_extensions = ['.pyc', '.pyo', '.o', '.swp']
+
+    def should_ignore(self, filename):
+        """Should ignore a given filename?"""
         _, ext = os.path.splitext(filename)
-        return ext in ['.pyc', '.pyo', '.o', '.swp']
+        return ext in self.ignored_extensions
+
+    def ignore_extension(self, extension):
+        self.ignored_extensions.append(extension)
 
     def watch(self, path, func=None, delay=0, ignore=None):
         """Add a task to watcher.
@@ -94,7 +100,7 @@ class Watcher(object):
         if not os.path.isfile(path):
             return False
 
-        if self.ignore(path):
+        if self.should_ignore(path):
             return False
 
         if ignore and ignore(path):


### PR DESCRIPTION
- Moved logging init further up the stack.
- Added methods to support ignoring file extensions.
- Updated README

```
$ ./manage.py livereload --ignore-file-extensions=.less,.scss
```