### PR TITLE
add templatetag for alternative to middleware

### DIFF
--- a/livereload/templatetags/livereload_tags.py
+++ b/livereload/templatetags/livereload_tags.py
@@ -1,0 +1,17 @@
+from django import template
+from django.conf import settings
+from django.utils.html import format_html
+from livereload import livereload_host, livereload_port
+
+register = template.Library()
+
+@register.simple_tag
+def livereload_script_tag():
+    if settings.DEBUG:
+        return format_html(
+        """<script src="{}:{}/livereload.js"></script>""",
+        livereload_host(),
+        livereload_port(),
+    )
+    else:
+        return ""


### PR DESCRIPTION
The use of beautifulsoup and the 'html.parser' creates a few issues in my html when using the livereload middleware to insert the livereload script into the `<head>` tag

I propose an addition that would allow me to manually place a template tag as I do with `django-hijack`

https://django-hijack.readthedocs.io/en/stable/#setting-up-the-notification-bar
https://github.com/arteria/django-hijack/blob/master/hijack/templatetags/hijack_tags.py