### PR TITLE
Fixes add_reader NotImplementedError on Python 3.8 + Windows.

### DIFF
--- a/livereload/server.py
+++ b/livereload/server.py
@@ -22,6 +22,10 @@ from .handlers import ForceReloadHandler
 from .watcher import get_watcher_class
 from six import string_types, PY3
 
+import asyncio, sys
+if sys.version_info >= (3, 8) and sys.platform == "win32":
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
 logger = logging.getLogger('livereload')
 
 


### PR DESCRIPTION
`asyncio`'s default event loop is changed in Python3.8, causing Tornado to break on Windows.

The fix is simply to ensure the old event loop is kept, when ran on Python >= 3.8, and on Windows.

More info can be found here:
* https://github.com/tornadoweb/tornado/issues/2608
* https://github.com/lepture/python-livereload/issues/209