### PR TITLE
changes getattr from settings to account for None values

### DIFF
--- a/livereload/__init__.py
+++ b/livereload/__init__.py
@@ -10,9 +10,9 @@ __url__ = 'https://github.com/tjwalch/django-livereload-server'
 
 def livereload_port():
     from django.conf import settings
-    return int(getattr(settings, 'LIVERELOAD_PORT', 35729))
+    return int(getattr(settings, 'LIVERELOAD_PORT', None) or 35729)
 
 
 def livereload_host():
     from django.conf import settings
-    return getattr(settings, 'LIVERELOAD_HOST', '127.0.0.1')
+    return getattr(settings, 'LIVERELOAD_HOST', None) or '127.0.0.1'


### PR DESCRIPTION
This change makes it easier to configure the port and host settings from environment variables.

For example, I might set this up in my settings.py as:

```
LIVERELOAD_HOST = os.getenv("LIVERELOAD_HOST")
LIVERELOAD_PORT = os.getenv("LIVERELOAD_PORT")
```

This makes it so that developers on my team can specify these values in their environment variables. The default return value for `getenv()` when the variable is not found is `None`. This PR makes sure that a value of `None` in the settings.py file does not break this livereload system.