### PR TITLE
Fix reload loop

### DIFF
--- a/livereload/handlers.py
+++ b/livereload/handlers.py
@@ -63,20 +63,21 @@ class LiveReloadHandler(WebSocketHandler):
 
     @classmethod
     def poll_tasks(cls):
-        filepath, delay = cls.watcher.examine()
-        if not filepath or delay == 'forever' or not cls.waiters:
+        filepaths, delay = cls.watcher.examine()
+        if len(filepaths) == 0 or delay == 'forever' or not cls.waiters:
             return
         reload_time = 3
 
         if delay:
-            reload_time = max(3 - delay, 1)
-        if filepath == '__livereload__':
+            reload_time = max(reload_time - delay, 1)
+        if '__livereload__' in filepaths:
             reload_time = 0
 
         if time.time() - cls._last_reload_time < reload_time:
             # if you changed lot of files in one time
             # it will refresh too many times
-            logger.info('Ignore: %s', filepath)
+            for filepath in filepaths:
+                logger.info('Ignore: %s', filepath)
             return
         if delay:
             loop = ioloop.IOLoop.current()
@@ -87,13 +88,16 @@ class LiveReloadHandler(WebSocketHandler):
     @classmethod
     def reload_waiters(cls, path=None):
         logger.info(
-            'Reload %s waiters: %s',
+            'Reload %s waiters: %s files modified',
             len(cls.waiters),
-            cls.watcher.filepath,
+            len(cls.watcher.filepaths),
         )
 
         if path is None:
-            path = cls.watcher.filepath or '*'
+            if len(cls.watcher.filepaths) == 1:
+                path = cls.watcher.filepaths[0]
+            else:
+                path = '*'
 
         msg = {
             'command': 'reload',

--- a/livereload/handlers.py
+++ b/livereload/handlers.py
@@ -76,8 +76,10 @@ class LiveReloadHandler(WebSocketHandler):
         if time.time() - cls._last_reload_time < reload_time:
             # if you changed lot of files in one time
             # it will refresh too many times
-            for filepath in filepaths:
-                logger.info('Ignore: %s', filepath)
+            if len(filepaths) == 1:
+                logger.info('Ignore: %s', filepaths[0])
+            else:
+                logger.info('Ignore: %s files', len(filepaths))
             return
         if delay:
             loop = ioloop.IOLoop.current()

--- a/livereload/handlers.py
+++ b/livereload/handlers.py
@@ -89,11 +89,18 @@ class LiveReloadHandler(WebSocketHandler):
 
     @classmethod
     def reload_waiters(cls, path=None):
-        logger.info(
-            'Reload %s waiters: %s files modified',
-            len(cls.waiters),
-            len(cls.watcher.filepaths),
-        )
+        if len(cls.watcher.filepaths) == 1:
+            logger.info(
+                'Reload %s waiters: %s',
+                len(cls.waiters),
+                cls.watcher.filepaths[0],
+            )
+        else: 
+            logger.info(
+                'Reload %s waiters: %s files modified',
+                len(cls.waiters),
+                len(cls.watcher.filepaths),
+            )
 
         if path is None:
             if len(cls.watcher.filepaths) == 1:

--- a/livereload/server.py
+++ b/livereload/server.py
@@ -157,7 +157,7 @@ class Server(object):
         self.application(host, liveport=liveport)
 
         try:
-            self.watcher._changes.append(('__livereload__', restart_delay))
+            self.watcher._changes.append((['__livereload__'], restart_delay))
             LiveReloadHandler.start_tasks()
             IOLoop.instance().start()
         except KeyboardInterrupt:

--- a/livereload/watcher.py
+++ b/livereload/watcher.py
@@ -27,8 +27,8 @@ class Watcher(object):
         # setting changes
         self._changes = []
 
-        # filepath that is changed
-        self.filepath = None
+        # filepaths that are changed
+        self.filepaths = []
         self._start = time.time()
 
         # ignored file extensions
@@ -69,8 +69,8 @@ class Watcher(object):
         if self._changes:
             return self._changes.pop()
 
-        # clean filepath
-        self.filepath = None
+        # clean filepaths
+        self.filepaths = []
         delays = set([0])
         for path in self._tasks:
             item = self._tasks[path]
@@ -85,7 +85,7 @@ class Watcher(object):
             delay = 'forever'
         else:
             delay = max(delays)
-        return self.filepath, delay
+        return self.filepaths, delay
 
     def is_changed(self, path, ignore=None):
         if isinstance(path, (list, tuple)):
@@ -110,18 +110,19 @@ class Watcher(object):
 
         if path not in self._mtimes:
             self._mtimes[path] = mtime
-            self.filepath = path
+            self.filepaths.append(path)
             return mtime > self._start
 
         if self._mtimes[path] != mtime:
             self._mtimes[path] = mtime
-            self.filepath = path
+            self.filepaths.append(path)
             return True
 
         self._mtimes[path] = mtime
         return False
 
     def is_folder_changed(self, path, ignore=None):
+        change = False
         for root, dirs, files in os.walk(path, followlinks=True):
             if '.git' in dirs:
                 dirs.remove('.git')
@@ -134,8 +135,8 @@ class Watcher(object):
 
             for f in files:
                 if self.is_file_changed(os.path.join(root, f), ignore):
-                    return True
-        return False
+                    change = True
+        return change
 
     def is_glob_changed(self, path, ignore=None):
         try:


### PR DESCRIPTION
This change checks for all files changed (and updates their modified times) before sending the reload message.  

This fixes #48 and #26 by reloading the page only once rather than entering a reload loop caused by a reload message being sent for each file that has been changed.   