### PR TITLE
Specify that the livereload server uses http

### DIFF
--- a/livereload/templatetags/livereload_tags.py
+++ b/livereload/templatetags/livereload_tags.py
@@ -9,7 +9,7 @@ register = template.Library()
 def livereload_script():
     if settings.DEBUG:
         return format_html(
-        """<script src="{}:{}/livereload.js"></script>""",
+        """<script src="http://{}:{}/livereload.js"></script>""",
         livereload_host(),
         livereload_port(),
     )


### PR DESCRIPTION
This should make the server work out of the box, as right now the default host IP gets included as-is, causing it to be read as a relative path.