### PR TITLE
Log no head tag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Next you need to inject the loading of the livereload javascript. You can do thi
     {% livereload_script %}
     </head>
 
-Either of these options will inject the ``livereload.js`` script into your webpages if ``DEBUG`` setting is on.
+Either of these options will inject the ``livereload.js`` script into your webpages if ``DEBUG`` setting is on and a head tag is present.
 
 Configuration
 -------------

--- a/livereload/middleware.py
+++ b/livereload/middleware.py
@@ -1,6 +1,7 @@
 """
 Middleware for injecting the live-reload script.
 """
+import logging
 from bs4 import BeautifulSoup
 
 from django.utils.encoding import smart_str
@@ -12,6 +13,7 @@ except ImportError:
 
 from livereload import livereload_port, livereload_host
 
+logger = logging.getLogger("django.server")
 
 class LiveReloadScript(MiddlewareMixin):
     """
@@ -32,6 +34,7 @@ class LiveReloadScript(MiddlewareMixin):
 
         head = getattr(soup, 'head', None)
         if not head:
+            logger.info("No head tag found. Live-reload script not injected.")
             return response
 
         script = soup.new_tag(


### PR DESCRIPTION
This change adds a warning if no head tag is present and livereload.js cannot be injected. It also updates the README to specify that a head tag is required. Fixing #50. 