### PR TITLE
Fix livereload command

### DIFF
--- a/livereload/management/commands/livereload.py
+++ b/livereload/management/commands/livereload.py
@@ -70,5 +70,5 @@ class Command(BaseCommand):
 
         server.serve(
             host=options['host'],
-            liveport=options['port'],
+            port=options['port'],
         )


### PR DESCRIPTION
Hey @tjwalch 

I went ahead and merged two PRs which are still sitting out in your main repo:

- https://github.com/tjwalch/django-livereload-server/pull/43
- https://github.com/tjwalch/django-livereload-server/pull/61

If you merge the above two, you should see the diff shrink for this MR.

I also fixed an issue with calling the livereload command. It was not picking up the `LIVERELOAD_PORT` which was set in the settings.

For anyone who wants to use this version in their project, it's hosted here:

https://gitlab.com/obuilds/public/django-livereload-server/-/tags/ob-v3

It can be included in a requirements.txt file like this:

`git+https://gitlab.com/obuilds/public/django-livereload-server@ob-v3`