### PR TITLE
Rename MIDDLEWARE_CLASSES => MIDDLEWARE in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,9 +22,9 @@ Add ``'livereload'`` to the ``INSTALLED_APPS``, before ``'django.contrib.staticf
 
 Next you need to inject the loading of the livereload javascript. You can do this in one of two ways:
 
-* Through middleware by adding  ``'livereload.middleware.LiveReloadScript'`` to ``MIDDLEWARE_CLASSES`` (probably at the end)::
+* Through middleware by adding  ``'livereload.middleware.LiveReloadScript'`` to ``MIDDLEWARE`` (probably at the end)::
 
-    MIDDLEWARE_CLASSES = (
+    MIDDLEWARE = (
         ...
         'livereload.middleware.LiveReloadScript',
     )


### PR DESCRIPTION
The README contains invalid instructions for modern Django, as it references `MIDDLEWARE_CLASSES` rather than just `MIDDLEWARE` . A quick check showed this changed back in Django 1.10, which is long out of support. The docs should show the correct value for `settings.py`. 

Note this caused at least one person some confusion ... https://stackoverflow.com/questions/76991281/django-livereload-server-installation 